### PR TITLE
Support tagging in mailgun

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ usedevelop = true
 ; If you want to make tox run the tests with the same versions, create a
 ; requirements.txt with the pinned versions and uncomment the following lines:
 deps =
-    --editable=git+https://github.com/websauna/websauna.git#egg=websauna
+    ; --editable=git+https://github.com/websauna/websauna.git#egg=websauna
     --editable=git+https://github.com/websauna/pytest-splinter.git#egg=pytest-splinter
     --editable=git+https://github.com/websauna/splinter.git#egg=splinter
     --editable=git+https://github.com/websauna/websauna.magiclogin#egg=websauna.magiclogin
@@ -31,6 +31,7 @@ deps =
     codecov
     flake8
     isort
+    websauna
 
 commands =
     py.test --timeout=2400 websauna/newsletter {posargs}

--- a/websauna/newsletter/mailgun.py
+++ b/websauna/newsletter/mailgun.py
@@ -100,7 +100,7 @@ class Mailgun:
             "o:tracking": yesify(tracking),
             "o:tracking-clicks": yesify(tracking_clicks),
             "o:tracking-opens": yesify(tracking_opens),
-            "o:tag": ','.join(map(str, tags)),
+            "o:tag": tags,
         }
 
         if campaign:

--- a/websauna/newsletter/mailgun.py
+++ b/websauna/newsletter/mailgun.py
@@ -80,7 +80,7 @@ class Mailgun:
         """
         return self.make_request("lists/{}/members".format(address), **data)
 
-    def send(self, domain: str, to: str, from_: str, subject: str, text: str, html: str, campaign=None, testmode=False, tracking=True, tracking_clicks=True, tracking_opens=True):
+    def send(self, domain: str, to: str, from_: str, subject: str, text: str, html: str, campaign=None, testmode=False, tracking=True, tracking_clicks=True, tracking_opens=True, tags=[]):
         """Send a newsletter or single message.
 
         See
@@ -100,6 +100,7 @@ class Mailgun:
             "o:tracking": yesify(tracking),
             "o:tracking-clicks": yesify(tracking_clicks),
             "o:tracking-opens": yesify(tracking_opens),
+            "o:tag": ','.join(map(str, tags)),
         }
 
         if campaign:

--- a/websauna/newsletter/sender.py
+++ b/websauna/newsletter/sender.py
@@ -7,7 +7,7 @@ from .tasks import send_newsletter_task
 logger = logging.getLogger(__name__)
 
 
-def send_newsletter(request, subject: str, preview_email=None, testmode=False, now_=None, import_subscribers=False):
+def send_newsletter(request, subject: str, preview_email=None, testmode=False, now_=None, import_subscribers=False, tags=[]):
     """Send newsletter.
 
     The HTML is mangled through premailer.
@@ -21,4 +21,4 @@ def send_newsletter(request, subject: str, preview_email=None, testmode=False, n
     """
 
     logger.info("Scheduling newsletter task %s, preview %s, import subscribers %s", subject, preview_email, import_subscribers)
-    send_newsletter_task.apply_async(args=(subject, preview_email, testmode, now_, import_subscribers), tm=request.tm)
+    send_newsletter_task.apply_async(args=(subject, preview_email, testmode, now_, import_subscribers, tags), tm=request.tm)

--- a/websauna/newsletter/tasks.py
+++ b/websauna/newsletter/tasks.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 
 @task(base=ScheduleOnCommitTask, bind=True)
-def send_newsletter_task(self: ScheduleOnCommitTask, subject, preview_email, testmode, now_, import_subscribers):
+def send_newsletter_task(self: ScheduleOnCommitTask, subject, preview_email, testmode, now_, import_subscribers, tags):
     """Do user import and newsletter inside a Celery worker process.
 
     We carefully split transaction handling to several parts.
@@ -68,8 +68,8 @@ def send_newsletter_task(self: ScheduleOnCommitTask, subject, preview_email, tes
         logger.info("Importing subscribers")
         import_all_users(mailgun, request.dbsession, mailing_list, tm=request.tm)
 
-    logger.info("Sending out newsletter %s %s %s %s %s", domain, subject, to, from_, campaign)
-    mailgun.send(domain, to, from_, subject, text, html, campaign)
+    logger.info("Sending out newsletter %s %s %s %s %s", domain, subject, to, from_, campaign, tags)
+    mailgun.send(domain, to, from_, subject, text, html, campaign, tags)
 
     if not preview_email:
         # Only mark newsletter send if not preview

--- a/websauna/newsletter/tasks.py
+++ b/websauna/newsletter/tasks.py
@@ -69,7 +69,7 @@ def send_newsletter_task(self: ScheduleOnCommitTask, subject, preview_email, tes
         import_all_users(mailgun, request.dbsession, mailing_list, tm=request.tm)
 
     logger.info("Sending out newsletter %s %s %s %s %s", domain, subject, to, from_, campaign, tags)
-    mailgun.send(domain, to, from_, subject, text, html, campaign, tags)
+    mailgun.send(domain, to, from_, subject, text, html, campaign, tags=tags)
 
     if not preview_email:
         # Only mark newsletter send if not preview

--- a/websauna/newsletter/tests/test_mailgun.py
+++ b/websauna/newsletter/tests/test_mailgun.py
@@ -32,5 +32,5 @@ def test_send_news_letter(mailgun, populated_mailing_list, domain):
     campaign = "TAGGGGED"
     testmode = True
 
-    resp = mailgun.send(domain, to, from_, subject, text, html, campaign, testmode)
+    resp = mailgun.send(domain, to, from_, subject, text, html, campaign, testmode, ['tag1', 'tag2'])
     assert "id" in resp


### PR DESCRIPTION
This is a PR for adding tagging feature of mailgun, as in https://documentation.mailgun.com/en/latest/user_manual.html#tagging

- by default: newsletters will have tags: newsletter, {subject}, {sending time}
- tags can be customised in admin view