### PR TITLE
Fix Typo in demo.py

### DIFF
--- a/websauna/newsletter/demo.py
+++ b/websauna/newsletter/demo.py
@@ -40,7 +40,7 @@ class Initializer(websauna.system.DemoInitializer):
         super(Initializer, self).configure_templates()
 
         # Your app templates go here
-        self.config.add_jinja2_search_path('websauna.magiclogin:demotemplates', name='.html', prepend=True)
+        self.config.add_jinja2_search_path('websauna.newsletter:demotemplates', name='.html', prepend=True)
 
     def run(self):
         super(Initializer, self).run()


### PR DESCRIPTION
Template path pointed to websauna.magiclogin instead of websauna.newsletter.